### PR TITLE
build(deps): bump pyjwt[crypto] from 2.9.0 to 2.10.1 in the python group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,7 +157,7 @@ RUN  apt-get update \
 && bash /tmp/nodesource_setup.sh \
 && apt-get install -y nodejs=20.19.4-1nodesource1 --no-install-recommends \
 # Install Chromium for mermaid-cli diagram generation
-&& apt-get install -y chromium=139.0.7258.127-1~deb12u1 --no-install-recommends \
+&& apt-get install -y chromium=138.0.7204.183-1~deb12u1 --no-install-recommends \
 # Install presentation tools globally
 && npm install -g @marp-team/marp-cli@4.2.3 @mermaid-js/mermaid-cli@11.9.0 \
 # Set Puppeteer to use system Chromium

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "psycopg2==2.9.10",
     "pydantic[email]==2.11.7",
     "pydantic-settings==2.10.1",
-    "pyjwt[crypto]==2.9.0",
+    "pyjwt[crypto]==2.10.1",
     "python-multipart==0.0.20",
     "pyyaml==6.0.2",
     "requests==2.32.4",

--- a/uv.lock
+++ b/uv.lock
@@ -533,7 +533,7 @@ requires-dist = [
     { name = "psycopg2", specifier = "==2.9.10" },
     { name = "pydantic", extras = ["email"], specifier = "==2.11.7" },
     { name = "pydantic-settings", specifier = "==2.10.1" },
-    { name = "pyjwt", extras = ["crypto"], specifier = "==2.9.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = "==2.10.1" },
     { name = "python-multipart", specifier = "==0.0.20" },
     { name = "pyyaml", specifier = "==6.0.2" },
     { name = "requests", specifier = "==2.32.4" },
@@ -1167,11 +1167,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.9.0"
+version = "2.10.1"
 source = { registry = "https://pypi.python.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fb/68/ce067f09fca4abeca8771fe667d89cc347d1e99da3e093112ac329c6020e/pyjwt-2.9.0.tar.gz", hash = "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c", size = 78825, upload-time = "2024-08-01T15:01:08.445Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/84/0fdf9b18ba31d69877bd39c9cd6052b47f3761e9910c15de788e519f079f/PyJWT-2.9.0-py3-none-any.whl", hash = "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850", size = 22344, upload-time = "2024-08-01T15:01:06.481Z" },
+    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Bumps the python group with 1 update: [pyjwt[crypto]](https://github.com/jpadilla/pyjwt).

Updates `pyjwt[crypto]` from 2.9.0 to 2.10.1
- [Release notes](https://github.com/jpadilla/pyjwt/releases)
- [Changelog](https://github.com/jpadilla/pyjwt/blob/master/CHANGELOG.rst)
- [Commits](https://github.com/jpadilla/pyjwt/compare/2.9.0...2.10.1)

---
updated-dependencies:
- dependency-name: pyjwt[crypto] dependency-version: 2.10.1 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: python ...

## Description

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->

## Jira Ticket

[ticket-id](url)

## Checklist

<!-- Please check everything that applies: -->

- [ ] I have reviewed my code and checked that there are no unrelated changes in this pull request (old patches, accidental config files, etc)
- [ ] I have created at least one test case for the changes I have made
- [ ] I have updated the documentation (**SwaggerHub**, **README.md**, **Wiki**, etc.) for the changes I have made
